### PR TITLE
Support RTL in MDCChipCollectionViewFlowLayout

### DIFF
--- a/components/Chips/src/MDCChipCollectionViewFlowLayout.m
+++ b/components/Chips/src/MDCChipCollectionViewFlowLayout.m
@@ -59,4 +59,8 @@ static inline CGRect CGRectLeftAlign(CGRect rect) {
   return [customLayoutAttributes copy];
 }
 
+- (BOOL)flipsHorizontallyInOppositeLayoutDirection {
+  return YES;
+}
+
 @end


### PR DESCRIPTION
Override -flipsHorizontallyInOppositeLayoutDirection to return YES in the MDCChipCollectionViewFlowLayout so that cells are laid out from right to left instead of left to right when the device layout is RTL.

(see https://developer.apple.com/documentation/uikit/uicollectionviewlayout/2891099-flipshorizontallyinoppositelayou?language=objc)

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [ ] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [ ] Link to GitHub issues it solves. ```closes #1234```
- [ ] Sign the CLA bot. You can do this once the pull request is opened.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
